### PR TITLE
Add memory profiling and switch to confluent Kafka client

### DIFF
--- a/Dockerfile-monitor
+++ b/Dockerfile-monitor
@@ -4,7 +4,6 @@ RUN pip install pipenv
 WORKDIR /monitor
 COPY . /monitor/
 RUN apt-get update
-RUN apt-get -y install librdkafka1 librdkafka-dev
-RUN RDKAFKA_INSTALL=system pipenv install
+RUN pipenv install
 ENV PYTHONUNBUFFERED 1
 CMD PYTHONPATH=. pipenv run python crawl_monitor/monitor.py

--- a/Dockerfile-monitor
+++ b/Dockerfile-monitor
@@ -6,5 +6,5 @@ COPY . /monitor/
 RUN apt-get update
 RUN apt-get -y install librdkafka1 librdkafka-dev
 RUN RDKAFKA_INSTALL=system pipenv install
-
+ENV PYTHONUNBUFFERED 1
 CMD PYTHONPATH=. pipenv run python crawl_monitor/monitor.py

--- a/Dockerfile-worker
+++ b/Dockerfile-worker
@@ -4,7 +4,7 @@ RUN pip install pipenv
 WORKDIR /worker
 COPY . /worker/
 RUN apt-get update
-RUN apt-get -y install librdkafka1 librdkafka-dev libmagickwand-dev
-RUN RDKAFKA_INSTALL=system pipenv install
+RUN apt-get -y install libmagickwand-dev
+RUN pipenv install
 ENV PYTHONUNBUFFERED 1
 CMD PYTHONPATH=. pipenv run python worker/scheduler.py

--- a/Dockerfile-worker
+++ b/Dockerfile-worker
@@ -6,5 +6,5 @@ COPY . /worker/
 RUN apt-get update
 RUN apt-get -y install librdkafka1 librdkafka-dev libmagickwand-dev
 RUN RDKAFKA_INSTALL=system pipenv install
-
+ENV PYTHONUNBUFFERED 1
 CMD PYTHONPATH=. pipenv run python worker/scheduler.py

--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,7 @@ PyExifTool = "*"
 exifread = "*"
 wand = "*"
 multiprocessing-logging = "*"
+pympler = "*"
 
 [dev-packages]
 

--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ exifread = "*"
 wand = "*"
 multiprocessing-logging = "*"
 pympler = "*"
+confluent-kafka = "*"
 
 [dev-packages]
 

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,6 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-pykafka = "*"
 aiohttp = "*"
 Pillow = "*"
 boto3 = "*"
@@ -13,10 +12,10 @@ aioredis = "*"
 aredis = "*"
 redis = "*"
 PyExifTool = "*"
-exifread = "*"
-wand = "*"
+ExifRead = "*"
+Wand = "*"
 multiprocessing-logging = "*"
-pympler = "*"
+Pympler = "*"
 confluent-kafka = "*"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "118255d245083f084fc42cdbf3565832c03fc747216b4d7c5046960a0b7f5b5a"
+            "sha256": "686902b84edc68a97e85b376fae2c64f05c7f3931899c9ccc5eb4a684b4dfc13"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -65,18 +65,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:2616351c98eec18d20a1d64b33355c86cd855ac96219d1b8428c9bfc590bde53",
-                "sha256:7daad26a008c91dd7b82fde17d246d1fe6e4b3813426689ef8bac9017a277cfb"
+                "sha256:77d926c16ab2ab2bfe68811f3bc987e7d79c97f3e2adebf9265c587cdb1fc47b",
+                "sha256:7f558165eaa608a5d0e05227ee820f4b3cc74533a52c9dde7eb488eba091d50d"
             ],
             "index": "pypi",
-            "version": "==1.14.12"
+            "version": "==1.14.13"
         },
         "botocore": {
             "hashes": [
-                "sha256:45934d880378777cefeca727f369d1f5aebf6b254e9be58e7c77dd0b059338bb",
-                "sha256:a94e0e2307f1b9fe3a84660842909cd2680b57a9fc9fb0c3a03b0afb2eadbe21"
+                "sha256:37b65cc48c99b7dd4d5606e56f76ecd88eb7be392ea8a166df734a6b3035301c",
+                "sha256:5ac9b53a75852fe4282be8741c8136e6948714fef6eff1bd9babb861f8647ba3"
             ],
-            "version": "==1.17.12"
+            "version": "==1.17.13"
         },
         "chardet": {
             "hashes": [
@@ -200,13 +200,6 @@
             ],
             "version": "==0.10.0"
         },
-        "kazoo": {
-            "hashes": [
-                "sha256:8db774f7bdece7d0dc7decb21539ff0852e42c2ffe1c28d7f1ff6f9292a1c3a4",
-                "sha256:a5fa2e400c5068cfee9e86b35cf0dab8232b574152d8e3590d823b3e2426ab5e"
-            ],
-            "version": "==2.5.0"
-        },
         "more-itertools": {
             "hashes": [
                 "sha256:68c70cc7167bdf5c7c9d8f6954a7837089c6a36bf565383919bb595efb8a17e5",
@@ -252,32 +245,35 @@
         },
         "pillow": {
             "hashes": [
-                "sha256:04766c4930c174b46fd72d450674612ab44cca977ebbcc2dde722c6933290107",
-                "sha256:0e2a3bceb0fd4e0cb17192ae506d5f082b309ffe5fc370a5667959c9b2f85fa3",
-                "sha256:0f01e63c34f0e1e2580cc0b24e86a5ccbbfa8830909a52ee17624c4193224cd9",
-                "sha256:12e4bad6bddd8546a2f9771485c7e3d2b546b458ae8ff79621214119ac244523",
-                "sha256:1f694e28c169655c50bb89a3fa07f3b854d71eb47f50783621de813979ba87f3",
-                "sha256:3d25dd8d688f7318dca6d8cd4f962a360ee40346c15893ae3b95c061cdbc4079",
-                "sha256:4b02b9c27fad2054932e89f39703646d0c543f21d3cc5b8e05434215121c28cd",
-                "sha256:70e3e0d99a0dcda66283a185f80697a9b08806963c6149c8e6c5f452b2aa59c0",
-                "sha256:9744350687459234867cbebfe9df8f35ef9e1538f3e729adbd8fde0761adb705",
-                "sha256:a0b49960110bc6ff5fead46013bcb8825d101026d466f3a4de3476defe0fb0dd",
-                "sha256:ae2b270f9a0b8822b98655cb3a59cdb1bd54a34807c6c56b76dd2e786c3b7db3",
-                "sha256:b37bb3bd35edf53125b0ff257822afa6962649995cbdfde2791ddb62b239f891",
-                "sha256:b532bcc2f008e96fd9241177ec580829dee817b090532f43e54074ecffdcd97f",
-                "sha256:b67a6c47ed963c709ed24566daa3f95a18f07d3831334da570c71da53d97d088",
-                "sha256:b943e71c2065ade6fef223358e56c167fc6ce31c50bc7a02dd5c17ee4338e8ac",
-                "sha256:ccc9ad2460eb5bee5642eaf75a0438d7f8887d484490d5117b98edd7f33118b7",
-                "sha256:d23e2aa9b969cf9c26edfb4b56307792b8b374202810bd949effd1c6e11ebd6d",
-                "sha256:eaa83729eab9c60884f362ada982d3a06beaa6cc8b084cf9f76cae7739481dfa",
-                "sha256:ee94fce8d003ac9fd206496f2707efe9eadcb278d94c271f129ab36aa7181344",
-                "sha256:f455efb7a98557412dc6f8e463c1faf1f1911ec2432059fa3e582b6000fc90e2",
-                "sha256:f46e0e024346e1474083c729d50de909974237c72daca05393ee32389dabe457",
-                "sha256:f54be399340aa602066adb63a86a6a5d4f395adfdd9da2b9a0162ea808c7b276",
-                "sha256:f784aad988f12c80aacfa5b381ec21fd3f38f851720f652b9f33facc5101cf4d"
+                "sha256:0295442429645fa16d05bd567ef5cff178482439c9aad0411d3f0ce9b88b3a6f",
+                "sha256:06aba4169e78c439d528fdeb34762c3b61a70813527a2c57f0540541e9f433a8",
+                "sha256:09d7f9e64289cb40c2c8d7ad674b2ed6105f55dc3b09aa8e4918e20a0311e7ad",
+                "sha256:0a80dd307a5d8440b0a08bd7b81617e04d870e40a3e46a32d9c246e54705e86f",
+                "sha256:1ca594126d3c4def54babee699c055a913efb01e106c309fa6b04405d474d5ae",
+                "sha256:25930fadde8019f374400f7986e8404c8b781ce519da27792cbe46eabec00c4d",
+                "sha256:431b15cffbf949e89df2f7b48528be18b78bfa5177cb3036284a5508159492b5",
+                "sha256:52125833b070791fcb5710fabc640fc1df07d087fc0c0f02d3661f76c23c5b8b",
+                "sha256:5e51ee2b8114def244384eda1c82b10e307ad9778dac5c83fb0943775a653cd8",
+                "sha256:612cfda94e9c8346f239bf1a4b082fdd5c8143cf82d685ba2dba76e7adeeb233",
+                "sha256:6d7741e65835716ceea0fd13a7d0192961212fd59e741a46bbed7a473c634ed6",
+                "sha256:6edb5446f44d901e8683ffb25ebdfc26988ee813da3bf91e12252b57ac163727",
+                "sha256:725aa6cfc66ce2857d585f06e9519a1cc0ef6d13f186ff3447ab6dff0a09bc7f",
+                "sha256:8dad18b69f710bf3a001d2bf3afab7c432785d94fcf819c16b5207b1cfd17d38",
+                "sha256:94cf49723928eb6070a892cb39d6c156f7b5a2db4e8971cb958f7b6b104fb4c4",
+                "sha256:97f9e7953a77d5a70f49b9a48da7776dc51e9b738151b22dacf101641594a626",
+                "sha256:9ad7f865eebde135d526bb3163d0b23ffff365cf87e767c649550964ad72785d",
+                "sha256:a060cf8aa332052df2158e5a119303965be92c3da6f2d93b6878f0ebca80b2f6",
+                "sha256:c79f9c5fb846285f943aafeafda3358992d64f0ef58566e23484132ecd8d7d63",
+                "sha256:c92302a33138409e8f1ad16731568c55c9053eee71bb05b6b744067e1b62380f",
+                "sha256:d08b23fdb388c0715990cbc06866db554e1822c4bdcf6d4166cf30ac82df8c41",
+                "sha256:d350f0f2c2421e65fbc62690f26b59b0bcda1b614beb318c81e38647e0f673a1",
+                "sha256:ec29604081f10f16a7aea809ad42e27764188fc258b02259a03a8ff7ded3808d",
+                "sha256:edf31f1150778abd4322444c393ab9c7bd2af271dd4dafb4208fb613b1f3cdc9",
+                "sha256:f7e30c27477dffc3e85c2463b3e649f751789e0f6c8456099eea7ddd53be4a8a",
+                "sha256:ffe538682dc19cc542ae7c3e504fdf54ca7f86fb8a135e59dd6bc8627eae6cce"
             ],
             "index": "pypi",
-            "version": "==7.1.2"
+            "version": "==7.2.0"
         },
         "pluggy": {
             "hashes": [
@@ -299,14 +295,6 @@
             ],
             "index": "pypi",
             "version": "==0.1.1"
-        },
-        "pykafka": {
-            "hashes": [
-                "sha256:6b075909a52cb0c95325bc16ab797bbcdbb37386652ea460705ed4472ce91459",
-                "sha256:f0bbd394ae6970042a587c99fe4dc0966e67787249d963d4ce2f810dc9490577"
-            ],
-            "index": "pypi",
-            "version": "==2.8.0"
         },
         "pympler": {
             "hashes": [
@@ -365,13 +353,6 @@
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
             "version": "==1.15.0"
-        },
-        "tabulate": {
-            "hashes": [
-                "sha256:ac64cb76d53b1231d364babcd72abbb16855adac7de6665122f97b593f1eb2ba",
-                "sha256:db2723a20d04bcda8522165c73eea7c300eda74e0ce852d9022e0159d7895007"
-            ],
-            "version": "==0.8.7"
         },
         "urllib3": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "809c51350fc10b7c1be42c95996dbc093eee417d91aff7432b049c197706c810"
+            "sha256": "d0a0eb92e36f53b34a9392149502bbc3e9e10f66e8998732799e73f29b69e1de"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -65,18 +65,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:7098937f6432e3ae4e5fe9b93f561b06117c5df736effb8cc166f6fb2bb41ab8",
-                "sha256:ed9b0852c0dc8ca88f5f851357acf238b954d1cced44f48e0d930d306150de7c"
+                "sha256:8eeaa2d6374f02d6f0d6b8bee55838add9a4246de81b1402e59372296402f6c7",
+                "sha256:d1d93ed75f477e8910b8b074ae76e3189d1c3a3998ea679ab52fdbacb8b4f390"
             ],
             "index": "pypi",
-            "version": "==1.14.5"
+            "version": "==1.14.11"
         },
         "botocore": {
             "hashes": [
-                "sha256:072c82c64906996f1d7953da1a61d8e6debf0ee5acaa267ec777f05b30755b66",
-                "sha256:fcfc3762472aa1d758583d818faaa59b933d839a87f372688836d49d66ad9a7a"
+                "sha256:64454a6dff9a3ced0dd75c0e69a8842aa663e0682d1dc5c8913fb76d354bfe3d",
+                "sha256:715b41f3215214e75bf7b8e88bdbc38dc055eef761b37dbd559bac1a5becb3c2"
             ],
-            "version": "==1.17.5"
+            "version": "==1.17.11"
         },
         "chardet": {
             "hashes": [
@@ -256,10 +256,10 @@
         },
         "py": {
             "hashes": [
-                "sha256:a673fa23d7000440cc885c17dbd34fafcb7d7a6e230b29f6766400de36a33c44",
-                "sha256:f3b3a4c36512a4c4f024041ab51866f11761cc169670204b235f6b20523d4e6b"
+                "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2",
+                "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"
             ],
-            "version": "==1.8.2"
+            "version": "==1.9.0"
         },
         "pyexiftool": {
             "hashes": [
@@ -275,6 +275,13 @@
             ],
             "index": "pypi",
             "version": "==2.8.0"
+        },
+        "pympler": {
+            "hashes": [
+                "sha256:f74cd2982c5cd92ded55561191945616f2bb904a0ae5cdacdb566c6696bdb922"
+            ],
+            "index": "pypi",
+            "version": "==0.8"
         },
         "pyparsing": {
             "hashes": [
@@ -292,10 +299,11 @@
         },
         "pytest-asyncio": {
             "hashes": [
-                "sha256:475bd2f3dc0bc11d2463656b3cbaafdbec5a47b47508ea0b329ee693040eebd2"
+                "sha256:2eae1e34f6c68fc0a9dc12d4bea190483843ff4708d24277c41568d6b6044f1d",
+                "sha256:9882c0c6b24429449f5f969a5158b528f39bde47dc32e85b9f0403965017e700"
             ],
             "index": "pypi",
-            "version": "==0.12.0"
+            "version": "==0.14.0"
         },
         "python-dateutil": {
             "hashes": [
@@ -351,10 +359,10 @@
         },
         "wcwidth": {
             "hashes": [
-                "sha256:79375666b9954d4a1a10739315816324c3e73110af9d0e102d906fdb0aec009f",
-                "sha256:8c6b5b6ee1360b842645f336d9e5d68c55817c26d3050f46b235ef2bc650e48f"
+                "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784",
+                "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"
             ],
-            "version": "==0.2.4"
+            "version": "==0.2.5"
         },
         "yarl": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d0a0eb92e36f53b34a9392149502bbc3e9e10f66e8998732799e73f29b69e1de"
+            "sha256": "118255d245083f084fc42cdbf3565832c03fc747216b4d7c5046960a0b7f5b5a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -65,18 +65,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:8eeaa2d6374f02d6f0d6b8bee55838add9a4246de81b1402e59372296402f6c7",
-                "sha256:d1d93ed75f477e8910b8b074ae76e3189d1c3a3998ea679ab52fdbacb8b4f390"
+                "sha256:2616351c98eec18d20a1d64b33355c86cd855ac96219d1b8428c9bfc590bde53",
+                "sha256:7daad26a008c91dd7b82fde17d246d1fe6e4b3813426689ef8bac9017a277cfb"
             ],
             "index": "pypi",
-            "version": "==1.14.11"
+            "version": "==1.14.12"
         },
         "botocore": {
             "hashes": [
-                "sha256:64454a6dff9a3ced0dd75c0e69a8842aa663e0682d1dc5c8913fb76d354bfe3d",
-                "sha256:715b41f3215214e75bf7b8e88bdbc38dc055eef761b37dbd559bac1a5becb3c2"
+                "sha256:45934d880378777cefeca727f369d1f5aebf6b254e9be58e7c77dd0b059338bb",
+                "sha256:a94e0e2307f1b9fe3a84660842909cd2680b57a9fc9fb0c3a03b0afb2eadbe21"
             ],
-            "version": "==1.17.11"
+            "version": "==1.17.12"
         },
         "chardet": {
             "hashes": [
@@ -84,6 +84,38 @@
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
+        },
+        "confluent-kafka": {
+            "hashes": [
+                "sha256:1b10a9e4ede8c7ee382c16075b55275963d3fe9b8eec3fc511d0868847cc6eed",
+                "sha256:1c46cbc2eb0876f0cdbd33ed7ea684ed1b009a25b65cf87736d3506d2f4ae57e",
+                "sha256:2500a78334d642e49b98710722e548c0e3d5dc4c6eae63f02d66448678ed2922",
+                "sha256:2515771b18d190df2182881abcf02fe8fde0aab567402ff36295b35cd495de65",
+                "sha256:3150c8875511e2cea4086206f3c10448f744c9c35f9033fd0874c8c55f7b87e2",
+                "sha256:4b0a3c47f9183570e9ee77ae8c36080fbc1996045251e25772944e4dadf1db21",
+                "sha256:4f875798bbc766767b9c6ed95b084fde851e0bf074527ab0daffa87f4e750635",
+                "sha256:515049659b045b99e0464d5ff5def4785478490563bc5ac1341a4f29dc335e82",
+                "sha256:52088adf1abdf3a384a54ec7a3bfaa0b61e5da8cc03a2e26a8351bbbf49f72a9",
+                "sha256:5342d3ff348b8082eaa4c63f4c82a72f3bf0ef8efa12a8580c890fa6e160f761",
+                "sha256:55734905c5a8642e596cf1e60ec4d86f05d31a185cbc71d1c73430bb0c08db19",
+                "sha256:624349587e97135996383c58edd8d53b38c57d653e6536c1f816049fc75faea3",
+                "sha256:804a7d71b3cb61444930af67986064c9555b8c33f05a27003ea314d6c847e522",
+                "sha256:931231853cec933addfafa27772177dcfab899d82e2e39fe7485c0602088daf7",
+                "sha256:a4f5edc1d7958bbf5f12ba83c1f83e22a66daa9c4318c7f28c5bb1db9289fe09",
+                "sha256:a591936a90095144451f041315239b2c823b7a15fa820cf45e45c422591345d6",
+                "sha256:a6eb8f3f553e98a6ef0d00f9cf8e4e8dde73c914a43a00fecef97330de80bcea",
+                "sha256:aa48215edcf16071d44ba29951c82c5f541d5ec915590aff0b4240e8e13f3ba3",
+                "sha256:bfacb9fa0e3a5e31a5ac9a5da15de656e95e7153e022ec5620095b76a6098ec0",
+                "sha256:bfbcbe7068690369ac2de3fe953854de34ad5e901157e96bcb990ca8b86d1d93",
+                "sha256:c2660807e5c1ecd723e280f76918794c3fd84595000c1e8de1f254f5d89a785c",
+                "sha256:c42ff838ee5e248f95f65b5adca4e2fdd4a2817fa26cede36d83a426e0f1370c",
+                "sha256:c5b741764d8ea2b8334fdaf4b56297c5bab780142f1c0cad0bd642cac30cb89e",
+                "sha256:dac33a04f73093de275953867a05de244560aa9842def6316cbb52bc0f02eff3",
+                "sha256:f1695a00789795f9f798588bb62688b563baf471a76ca20fa01c957844938d7d",
+                "sha256:f25836e03559a381ba74b9a6940b716e61ba8ae2db2d5d3a40accbc60617e1af"
+            ],
+            "index": "pypi",
+            "version": "==1.4.2"
         },
         "docutils": {
             "hashes": [
@@ -148,18 +180,18 @@
         },
         "idna": {
             "hashes": [
-                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
-                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
-            "version": "==2.9"
+            "version": "==2.10"
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:0505dd08068cfec00f53a74a0ad927676d7757da81b7436a6eefe4c7cf75c545",
-                "sha256:15ec6c0fd909e893e3a08b3a7c76ecb149122fb14b7efe1199ddd4c7c57ea958"
+                "sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83",
+                "sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==1.6.1"
+            "version": "==1.7.0"
         },
         "jmespath": {
             "hashes": [

--- a/crawl_monitor/source_splitter.py
+++ b/crawl_monitor/source_splitter.py
@@ -2,8 +2,6 @@ import json
 import logging as log
 import redis
 import crawl_monitor.settings as settings
-from pykafka.exceptions import SocketDisconnectedError
-
 
 NUM_SPLIT = 'num_split'
 SOURCE_SET = 'inbound_sources'
@@ -11,10 +9,10 @@ SOURCE_SET = 'inbound_sources'
 
 def parse_message(message):
     try:
-        decoded = json.loads(str(message.value, 'utf-8'))
+        decoded = json.loads(str(message.value(), 'utf-8'))
         decoded['source'] = decoded['source'].lower()
     except (json.JSONDecodeError, KeyError, TypeError, AttributeError):
-        log.error(f'Failed to parse message {message}')
+        log.error(f'Failed to parse message {message}', exc_info=True)
         return None
     return decoded
 
@@ -31,19 +29,19 @@ class SourceSplitter:
     {source: 'example2', uuid: xxxxxx, 'url': "xxxxx.org}
 
     Output:
-    topic: example1_urls:
+    topic: urls.example1:
     {uuid: xxxxxx, 'url': "xxxxx.org}
-    topic: example2_urls:
+    topic: urls.example1:
     {uuid: xxxxxx, 'url': "xxxxx.org}
 
     Each time a new topic is created, the name of the source gets
     put into the 'inbound_sources' set in Redis.
     """
 
-    def __init__(self, kafka_client, consumer):
-        self.kafka_client = kafka_client
+    def __init__(self, producer, consumer):
         # Map source to producer topic
-        self.producers = {}
+        self.producer = producer
+        self.sources = set()
         self.consumer = consumer
 
     def split(self):
@@ -51,24 +49,23 @@ class SourceSplitter:
         log.info('Starting splitter')
         while True:
             msg_count = 0
-            for msg in self.consumer:
-                parsed = parse_message(msg)
-                if parsed:
-                    source = parsed['source']
-                    if source not in self.producers:
-                        redis_client.sadd(SOURCE_SET, source)
-                        source_producer = self.kafka_client \
-                            .topics[f'{source}_urls'] \
-                            .get_producer(use_rdkafka=True)
-                        self.producers[source] = source_producer
-                    producer = self.producers[source]
-                    del parsed['source']
-                    encoded_msg = bytes(json.dumps(parsed), 'utf-8')
+            msg = self.consumer.poll(1.0)
+            if msg is None:
+                continue
+            parsed = parse_message(msg)
+            if parsed:
+                source = parsed['source']
+                if source not in self.sources:
+                    redis_client.sadd(SOURCE_SET, source)
+                    self.sources.add(source)
+                del parsed['source']
+                encoded_msg = bytes(json.dumps(parsed), 'utf-8')
+                while True:
                     try:
-                        producer.produce(encoded_msg)
-                    except SocketDisconnectedError:
-                        producer.stop()
-                        producer.start()
+                        self.producer.produce(f'urls.{source}', encoded_msg)
+                    except BufferError:
+                        self.producer.poll(1)
                     msg_count += 1
-                if msg_count % 1000 == 0:
-                    redis_client.incrby(NUM_SPLIT, 1000)
+                    break
+            if msg_count % 1000 == 0:
+                redis_client.incrby(NUM_SPLIT, 1000)

--- a/crawl_monitor/tsv_producer.py
+++ b/crawl_monitor/tsv_producer.py
@@ -4,7 +4,7 @@ import csv
 import argparse
 import logging as log
 from urllib.parse import urlparse
-from pykafka import KafkaClient
+from confluent_kafka import Producer
 
 """
 Schedules URLs for crawling from a TSV file.
@@ -45,20 +45,18 @@ tsv_path = parsed_args.tsv_path[0]
 in_tsv = open(tsv_path, 'r')
 hosts = parsed_args.kafka_hosts[0]
 log.info(f'Connecting to Kafka broker(s): {hosts}')
-client = KafkaClient(hosts=parsed_args.kafka_hosts[0])
-topic = client.topics['inbound_images']
 reader = csv.DictReader(in_tsv, delimiter='\t')
 start = time.monotonic()
 log.info('Beginning production of messages')
-with topic.get_producer(
-        use_rdkafka=True,
-        max_queued_messages=5000000,
-        block_on_queue_full=True
-) as producer:
-    for idx, row in enumerate(reader):
-        encoded = _parse_row(row)
-        producer.produce(encoded)
-        if idx % 10000 == 0:
-            log.info(f'Produced {idx} messages so far')
+producer = Producer({'bootstrap.servers': hosts})
+for idx, row in enumerate(reader):
+    encoded = _parse_row(row)
+    try:
+        producer.produce('inbound_images', encoded)
+    except BufferError:
+        log.info('Waiting for signal from producer...')
+        producer.poll(1)
+    if idx % 10000 == 0:
+        log.info(f'Produced {idx} messages so far')
 print(f'Produced {idx} at rate {idx / (time.monotonic() - start)}/s')
 in_tsv.close()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,6 @@ services:
       - zookeeper
       - kafka
     environment:
-      - PROFILE_MEMORY=true
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
       - AWS_DEFAULT_REGION

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       - zookeeper
       - kafka
     environment:
+      - PROFILE_MEMORY=true
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
       - AWS_DEFAULT_REGION

--- a/test/mocks.py
+++ b/test/mocks.py
@@ -35,7 +35,7 @@ class FakeProducer:
     def __init__(self):
         self.messages = []
 
-    def produce(self, msg):
+    def produce(self, topic, msg):
         log.info(f'producing {msg}')
         self.messages.append(msg)
 

--- a/test/test_worker.py
+++ b/test/test_worker.py
@@ -49,7 +49,7 @@ async def test_handles_corrupt_images_gracefully():
     redis = FakeRedis()
     stats = StatsManager(redis)
     kafka = FakeProducer()
-    producer = AsyncProducer(kafka)
+    producer = AsyncProducer(kafka, 'foo')
     await process_image(
         persister=validate_thumbnail,
         session=RateLimitedClientSession(FakeAioSession(corrupt=True), redis),
@@ -72,7 +72,7 @@ async def test_handled_404s():
     redis = FakeRedis()
     stats = StatsManager(redis)
     kafka = FakeProducer()
-    rot_producer = AsyncProducer(kafka)
+    rot_producer = AsyncProducer(kafka, 'foo')
     session = RateLimitedClientSession(
         FakeAioSession(corrupt=True, status=404), redis
     )
@@ -103,7 +103,7 @@ async def test_records_errors():
     stats = StatsManager(redis)
     session = RateLimitedClientSession(FakeAioSession(status=403), redis)
     retry_producer = FakeProducer()
-    producer = AsyncProducer(retry_producer)
+    producer = AsyncProducer(retry_producer, 'foo')
     await process_image(
         persister=validate_thumbnail,
         session=session,
@@ -144,7 +144,7 @@ async def producer_fixture():
     stats = StatsManager(redis)
     meta_producer = FakeProducer()
     retry_producer = FakeProducer()
-    producer = AsyncProducer(meta_producer)
+    producer = AsyncProducer(meta_producer, 'foo')
     await process_image(
         persister=validate_thumbnail,
         session=RateLimitedClientSession(FakeAioSession(), redis),

--- a/worker/image.py
+++ b/worker/image.py
@@ -17,7 +17,6 @@ RETRY_CODES = {
     403,
     429,
     500,
-    NO_RATE_TOKEN,
     SERVER_DISCONNECTED
 }
 

--- a/worker/message.py
+++ b/worker/message.py
@@ -20,13 +20,14 @@ class AsyncProducer:
     and intermittently send them to Kafka synchronously. Launch
     `MetadataProducer.listen` as an asyncio task to do this.
     """
-    def __init__(self, producer_topic, frequency=60):
+    def __init__(self, producer, topic_name, frequency=60):
         """
-        :param producer_topic: A pykafka producer.
+        :param producer: A pykafka producer.
         :param frequency: How often to publish queued events.
         """
         self.frequency = frequency
-        self.producer = producer_topic
+        self.producer = producer,
+        self.topic_name = topic_name
         self._messages = []
 
     def enqueue_message(self, msg: dict):
@@ -48,7 +49,7 @@ class AsyncProducer:
                 log.info(f'Publishing {queue_size} events')
                 start = time.monotonic()
                 for msg in self._messages:
-                    self.producer.produce(msg)
+                    self.producer.produce(self.topic_name, msg)
                 rate = queue_size / (time.monotonic() - start)
                 self._messages = []
                 log.info(f'publish_rate={rate}/s')
@@ -56,7 +57,7 @@ class AsyncProducer:
 
 
 def parse_message(message):
-    decoded = json.loads(str(message.value, 'utf-8'))
+    decoded = json.loads(str(message.value(), 'utf-8'))
     return decoded
 
 

--- a/worker/message.py
+++ b/worker/message.py
@@ -16,8 +16,8 @@ class AsyncProducer:
     database. This is accomplished by encoding the discovered metadata into
     a Kafka message and publishing it into the corresponding topic.
 
-    pykafka is not asyncio-friendly, so we need to batch our messages together
-    and intermittently send them to Kafka synchronously. Launch
+    The kafka client is not asyncio-friendly, so we need to batch our messages
+    together and intermittently send them to Kafka synchronously. Launch
     `MetadataProducer.listen` as an asyncio task to do this.
     """
     def __init__(self, producer, topic_name, frequency=60):
@@ -26,7 +26,7 @@ class AsyncProducer:
         :param frequency: How often to publish queued events.
         """
         self.frequency = frequency
-        self.producer = producer,
+        self.producer = producer
         self.topic_name = topic_name
         self._messages = []
 

--- a/worker/message.py
+++ b/worker/message.py
@@ -34,7 +34,9 @@ class AsyncProducer:
             _msg_json = json.dumps(msg)
             _msg = bytes(_msg_json, 'utf-8')
         except TypeError:
-            log.warning(f'Failed to encode message: {msg}')
+            ident = msg.get('identifier', '')
+            log.warning(f'Failed to encode message with keys: '
+                        f'{list([msg.keys()])}. Identifier: {ident}')
             return
         self._messages.append(_msg)
 

--- a/worker/scheduler.py
+++ b/worker/scheduler.py
@@ -158,7 +158,7 @@ class CrawlScheduler:
                         )
                     )
                     task_schedule[source].append(t)
-            if iterations % 100 == 0:
+            if settings.PROFILE_MEMORY and iterations % 100 == 0:
                 log.info('Memory delta:')
                 self.memtrack.print_diff()
             iterations += 1

--- a/worker/scheduler.py
+++ b/worker/scheduler.py
@@ -47,7 +47,9 @@ class CrawlScheduler:
         while len(msgs) < n and messages_remaining:
             msg = consumer.poll(timeout=0.1)
             if msg:
-                msgs.append(parse_message(msg))
+                parsed = parse_message(msg)
+                if parsed:
+                    msgs.append(parsed)
             else:
                 messages_remaining = False
         return msgs
@@ -221,7 +223,8 @@ async def listen():
 
 
 if __name__ == '__main__':
+    log.basicConfig(level=log.INFO, format='%(asctime)s %(message)s')
     log.basicConfig(level=log.INFO)
-    asyncio.run(listen())
+    asyncio.run(listen(), debug=True)
     log.info('Shutting down worker.')
     sys.exit(0)

--- a/worker/scheduler.py
+++ b/worker/scheduler.py
@@ -44,7 +44,7 @@ class CrawlScheduler:
         messages_remaining = True
         msgs = []
         while len(msgs) < n and messages_remaining:
-            msg = consumer.poll(timeout=0.5)
+            msg = consumer.poll(timeout=0.1)
             if msg:
                 msgs.append(parse_message(msg))
             else:
@@ -74,7 +74,7 @@ class CrawlScheduler:
             return self.consumers[source]
         except KeyError:
             consumer = Consumer(self.consumer_settings)
-            consumer.subscribe(f'urls.{source}')
+            consumer.subscribe([f'urls.{source}'])
             self.consumers[source] = consumer
             log.info(f'Set up new consumer for {source} urls')
             return consumer

--- a/worker/scheduler.py
+++ b/worker/scheduler.py
@@ -6,6 +6,7 @@ import aredis
 import math
 import boto3
 import botocore.client
+import sys
 from functools import partial
 from collections import defaultdict
 from worker.util import save_thumbnail_s3
@@ -223,3 +224,4 @@ if __name__ == '__main__':
     log.basicConfig(level=log.INFO)
     asyncio.run(listen())
     log.info('Shutting down worker.')
+    sys.exit(0)

--- a/worker/settings.py
+++ b/worker/settings.py
@@ -1,5 +1,7 @@
 import os
 
+true_strings = ['true', 'True', 't', '1']
+
 # S3
 AWS_ACCESS_KEY_ID = os.getenv('AWS_ACCESS_KEY_ID')
 AWS_SECRET_ACCESS_KEY = os.getenv('AWS_SECRET_ACCESS_KEY')
@@ -23,3 +25,5 @@ SCHEDULE_SIZE = int(os.getenv('SCHEDULE_SIZE', '3000'))
 # limit. Also be mindful that running too many coroutines simultaneously can
 # be detrimental to performance.
 MAX_TASKS = 3000
+
+PROFILE_MEMORY = os.getenv('PROFILE_MEMORY', 'False') in true_strings

--- a/worker/util.py
+++ b/worker/util.py
@@ -1,18 +1,4 @@
-import logging as log
-import time
 from io import BytesIO
-import pykafka
-import worker.settings as settings
-
-
-def kafka_connect():
-    try:
-        client = pykafka.KafkaClient(hosts=settings.KAFKA_HOSTS)
-    except pykafka.exceptions.NoBrokersAvailableError:
-        log.info('Retrying Kafka connection. . .')
-        time.sleep(3)
-        return kafka_connect()
-    return client
 
 
 def save_thumbnail_s3(s3_client, img: BytesIO, identifier):


### PR DESCRIPTION
Related to https://github.com/creativecommons/cccatalog-api/issues/513

## Description
`pykafka`'s integration with librdkafka seems to have some issues with leaky memory and handling an unreliable Kafka cluster in a predictable way. For example, when the crawler monitor loses its connection with Zookeeper, all of the memory of the machine is exhausted. I also encountered issues with the pykafka consumer taking up more resources than expected and rebalancing partitions too frequently in crawl workers.

These problems were making it hard to crawl more than 2 million URLs without experiencing failures in workers and the crawl monitor. As a result, I switched to `confluent_kafka`, which is maintained by the creators of Kafka.

In the course of hunting down this issue, I added some settings for tracking memory usage in workers.