### PR TITLE
Switch to process based concurrency model

### DIFF
--- a/analysis/rekognition_worker.py
+++ b/analysis/rekognition_worker.py
@@ -32,6 +32,7 @@ def enqueue(output_event: dict, kafka_producer):
     resp_json = json.dumps(output_event).encode('utf-8')
     kafka_producer.produce(LABELS_TOPIC, resp_json)
 
+
 def _monitor_futures(futures, output_producer):
     """
     Summarizes task progress and handles exceptions. Returns a list of pending

--- a/analysis/rekognition_worker.py
+++ b/analysis/rekognition_worker.py
@@ -24,7 +24,7 @@ MAX_PENDING_FUTURES = 1000
 # These are network-bound threads, it's OK to use a lot of them
 NUM_THREADS = 50
 # Number of recently processed image IDs to retain for duplication prevention
-NUM_RECENT_IMAGE_ID_RETENTION = 100000000
+NUM_RECENT_IMAGE_ID_RETENTION = 100
 LABELS_TOPIC = 'image_analysis_labels'
 
 

--- a/analysis/rekognition_worker.py
+++ b/analysis/rekognition_worker.py
@@ -21,8 +21,10 @@ MAX_REKOGNITION_RPS = 50
 # Number of pending messages to store simultaneously in memory
 NUM_MESSAGES_BUFFER = 1500
 MAX_PENDING_FUTURES = 1000
-# These are network-bound threads, it's OK to use a lot of them
-NUM_THREADS = 50
+# The maximum concurrency for processing requests. This should be tailored to
+# the underlying hardware; experimentation suggests 3 * NUM_CPUS maximizes
+# throughput in this use case.
+NUM_PROCS = 100
 # Number of recently processed image IDs to retain for duplication prevention
 NUM_RECENT_IMAGE_ID_RETENTION = 100
 LABELS_TOPIC = 'image_analysis_labels'
@@ -102,7 +104,7 @@ def listen(consumer, producer, task_fn):
     status_tracker = Counter({})
     msg_buffer = []
     futures = []
-    executor = concurrent.futures.ProcessPoolExecutor(max_workers=NUM_THREADS)
+    executor = concurrent.futures.ProcessPoolExecutor(max_workers=NUM_PROCS)
     msgs_remaining = True
     last_log = None
     token_bucket = LocalTokenBucket(MAX_REKOGNITION_RPS)

--- a/analysis/task.py
+++ b/analysis/task.py
@@ -1,8 +1,5 @@
-import json
 import boto3
 import enum
-
-LABELS_TOPIC = 'image_analysis_labels'
 
 
 class TaskStatus(enum.Enum):

--- a/analysis/util.py
+++ b/analysis/util.py
@@ -31,7 +31,6 @@ class LocalTokenBucket:
                     .Manager() \
                     .Value('i', self._MAX_TOKENS)
                 self._last_timestamp = now
-            print(f'tokens: {self._curr_tokens.value} {self._last_timestamp}')
             if self._curr_tokens.value <= 0:
                 return False
             self._curr_tokens.value -= 1

--- a/analysis/util.py
+++ b/analysis/util.py
@@ -51,7 +51,6 @@ class LocalTokenBucket:
 class RecentlyProcessed:
     """ Determine whether an item has been seen recently. (Multiproc-safe) """
     def __init__(self, retention_num):
-        #
         self._queue = multiprocessing.Manager().list()
         self._max_retain = retention_num
         self._lock = multiprocessing.Manager().Lock()

--- a/analysis/util.py
+++ b/analysis/util.py
@@ -1,6 +1,6 @@
 import json
 import logging as log
-import threading
+import multiprocessing
 import time
 from json import JSONDecodeError
 """
@@ -14,7 +14,7 @@ class LocalTokenBucket:
     """
     def __init__(self, max_val, refresh_rate_sec=1):
         self._refresh_rate_sec = refresh_rate_sec
-        self._lock = threading.Lock()
+        self._lock = multiprocessing.Manager().Lock()
         self._last_timestamp = None
         self._MAX_TOKENS = max_val
         self._curr_tokens = max_val
@@ -53,7 +53,7 @@ class RecentlyProcessed:
         # For remembering order of arrival
         self._queue = []
         self._max_retain = retention_num
-        self._lock = threading.Lock()
+        self._lock = multiprocessing.Manager().Lock()
 
     def seen_recently(self, item):
         with self._lock:

--- a/test/test_rekognition_worker.py
+++ b/test/test_rekognition_worker.py
@@ -20,11 +20,11 @@ def make_mock_msg():
 
 def mock_work_function(*args, **kwargs):
     time.sleep(1)
-    recent_ids = args[2]
+    recent_ids = args[1]
     if recent_ids:
         if recent_ids.seen_recently(args[0]):
             return TaskStatus.IGNORED_DUPLICATE
-    return TaskStatus.SUCCEEDED
+    return TaskStatus.SUCCEEDED, 'mock event output'
 
 
 def mock_work_fn_failure(*args, **kwargs):

--- a/test/test_rekognition_worker.py
+++ b/test/test_rekognition_worker.py
@@ -21,9 +21,8 @@ def make_mock_msg():
 def mock_work_function(*args, **kwargs):
     time.sleep(1)
     recent_ids = args[1]
-    if recent_ids:
-        if recent_ids.seen_recently(args[0]):
-            return TaskStatus.IGNORED_DUPLICATE
+    if recent_ids.seen_recently(args[0]):
+        return TaskStatus.IGNORED_DUPLICATE
     return TaskStatus.SUCCEEDED, 'mock event output'
 
 


### PR DESCRIPTION
## Related to creativecommons/cccatalog-api#584

We need to make exactly 50 requests per second to Rekognition to finish this task by our deadline. Using a ThreadPoolExecutor caused requests to be serialized due to the GIL (I assumed boto3 would be making calls to C extensions outside of the GIL but I was wrong). To get around this, I switched to a ProcessPoolExecutor and can confirm we're getting the desired performance now.

## Summary of changes:
- confluent-kafka Producer instances can't be passed between processes, so we need to do all the production in the main thread after the Rekognition task has been completed.
- Don't parse message JSON twice.
- Use IPC-friendly data structures in LocalTokenBucket and RecentlyProcessed to make this compatible with a process based concurrency model
- The deduplication retention policy has been reduced to the last 100 images. This data structure needs to be serialized over IPC every single time we call an image, which isn't very efficient once it gets large. We should still be able to prevent duplication even with the smaller retention policy.

## Testing
- Unit tests suggest this works with the new concurrency model
- I ran a smoke test on 30,000 images and am seeing the performance that I expect now.